### PR TITLE
Add support for Aria of Passion

### DIFF
--- a/Structs.h
+++ b/Structs.h
@@ -40,12 +40,14 @@ struct charstate_t
     bool                KnowsDispelga;
     bool                KnowsImpact;
     bool                KnowsHonorMarch;
+    bool                KnowsAriaOfPassion;
     charstate_t() :
         OverrideEntrust(std::chrono::steady_clock::now() - std::chrono::seconds(1)),
         OverridePianissimo(std::chrono::steady_clock::now() - std::chrono::seconds(1)),
         KnowsDispelga(false),
         KnowsImpact(false),
         KnowsHonorMarch(false),
+        KnowsAriaOfPassion(false),
     CharacterName(std::string("NO_NAME")) {}
 };
 struct settings_t
@@ -63,6 +65,7 @@ struct settings_t
     bool				UnlockDispelga;
     bool				UnlockImpact;
     bool				UnlockHonorMarch;
+    bool                UnlockAriaOfPassion;
     bool                Debug;
 
     settings_t() {}
@@ -74,6 +77,7 @@ struct settings_t
         UnlockDispelga(false),
         UnlockImpact(false),
         UnlockHonorMarch(false),
+        UnlockAriaOfPassion(false),
         Debug(false) {
             AbilityMap = std::map<std::string, uint16_t>();
             for (uint16_t x = 512; x < 1512; x++)

--- a/fileio.cpp
+++ b/fileio.cpp
@@ -34,6 +34,10 @@ void Shorthand::CreateSettingsXml(bool basic)
 	if (mSettings.UnlockHonorMarch) outstream << "true";
 	else outstream << "false";
 	outstream << "</honor>\n";
+	outstream << "\t\t<aria>";
+	if (mSettings.UnlockAriaOfPassion) outstream << "true";
+	else outstream << "false";
+	outstream << "</aria>\n";
 	outstream << "\t\t<dispelga>";
 	if (mSettings.UnlockDispelga) outstream << "true";
 	else outstream << "false";
@@ -133,6 +137,10 @@ void Shorthand::LoadSettingsXml(bool forceReload)
 				if (_stricmp(SubNode->name(), "honor") == 0)
 				{
 					if (_stricmp(SubNode->value(), "true") == 0) mSettings.UnlockHonorMarch = true;
+				}
+				if (_stricmp(SubNode->name(), "aria") == 0)
+				{
+					if (_stricmp(SubNode->value(), "true") == 0) mSettings.UnlockAriaOfPassion = true;
 				}
 				if (_stricmp(SubNode->name(), "debug") == 0)
 				{

--- a/helpers.cpp
+++ b/helpers.cpp
@@ -10,15 +10,18 @@ void Shorthand::InitializeSpells()
         return;
 
     //We know we're ingame, so we can fill in what we know.
-    mState.KnowsDispelga   = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(360);
-    mState.KnowsHonorMarch = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(417);
-    mState.KnowsImpact     = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(503);
+    mState.KnowsDispelga      = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(360);
+    mState.KnowsHonorMarch    = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(417);
+    mState.KnowsImpact        = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(503);
+    mState.KnowsAriaOfPassion = m_AshitaCore->GetMemoryManager()->GetPlayer()->HasSpell(418);
 
     //Once we fill in what we know, we can apply our overrides if applicable.
     if ((!mState.KnowsDispelga) && (mSettings.UnlockDispelga))
         SetSpellLearned(360, true);
     if ((!mState.KnowsHonorMarch) && (mSettings.UnlockHonorMarch))
         SetSpellLearned(417, true);
+    if ((!mState.KnowsAriaOfPassion) && (mSettings.UnlockAriaOfPassion))
+        SetSpellLearned(418, true);
     if ((!mState.KnowsImpact) && (mSettings.UnlockImpact))
         SetSpellLearned(503, true);
 }

--- a/main.cpp
+++ b/main.cpp
@@ -127,6 +127,19 @@ bool Shorthand::HandleCommand(int32_t mode, const char* command, bool injected)
 			if (!mState.KnowsHonorMarch) SetSpellLearned(417, mSettings.UnlockHonorMarch);
 		}
 
+		else if (CheckArg(1, "aria"))
+		{
+			if (CheckArg(2, "on"))
+				mSettings.UnlockAriaOfPassion = true;
+			else if (CheckArg(2, "off"))
+				mSettings.UnlockAriaOfPassion = false;
+			else
+				mSettings.UnlockAriaOfPassion = !mSettings.UnlockAriaOfPassion;
+
+			pOutput->message_f("Aria of Passion override $H%s$R.", mSettings.UnlockAriaOfPassion ? "enabled" : "disabled");
+			if (!mState.KnowsAriaOfPassion) SetSpellLearned(418, mSettings.UnlockAriaOfPassion);
+		}
+
 		else if (CheckArg(1, "export"))
 		{
 			CreateSettingsXml(false);
@@ -178,6 +191,7 @@ bool Shorthand::HandleIncomingPacket(uint16_t id, uint32_t size, const uint8_t* 
 	if (id == 0xAA)
 	{
 		//Set these.  If the game says we know it, we don't need to later check if we have the gear.
+		mState.KnowsAriaOfPassion = (Read8(data, 0x038) & 0x04);
 		mState.KnowsHonorMarch = (Read8(data, 0x38) & 0x02);
 		mState.KnowsDispelga = (Read8(data, 0x31) & 0x01);
 		mState.KnowsImpact = (Read8(data, 0x42) & 0x80);
@@ -186,6 +200,7 @@ bool Shorthand::HandleIncomingPacket(uint16_t id, uint32_t size, const uint8_t* 
 		if (mSettings.UnlockImpact) Write8(modified, 0x42) |= 0x80;
 		if (mSettings.UnlockDispelga) Write8(modified, 0x31) |= 0x01;
 		if (mSettings.UnlockHonorMarch) Write8(modified, 0x38) |= 0x02;
+		if (mSettings.UnlockAriaOfPassion) Write8(modified, 0x38) |= 0x04;
 	}
 
 	return false;
@@ -234,6 +249,16 @@ bool Shorthand::HandleOutgoingPacket(uint16_t id, uint32_t size, const uint8_t* 
 				if (!CheckForEquippableItem(21398))
 				{
 					pOutput->error("No marsyas in equippable bags.  Honor March packet blocked.");
+					return true;
+				}
+			}
+
+			if ((Read16(data, 12) == 418) && (!mState.KnowsAriaOfPassion))
+			{
+				uint16_t zoneId = m_AshitaCore->GetMemoryManager()->GetParty()->GetMemberZone(0);
+				if (!(CheckForEquippableItem(22305) && (zoneId == 275 || zoneId == 133 || zoneId == 189) && !CheckForEquippableItem(22306) && !CheckForEquippableItem(22307)))
+				{
+					pOutput->error("No Loughnashade in equippable bags.  Aria of Passion packet blocked.");
 					return true;
 				}
 			}

--- a/main.cpp
+++ b/main.cpp
@@ -256,7 +256,7 @@ bool Shorthand::HandleOutgoingPacket(uint16_t id, uint32_t size, const uint8_t* 
 			if ((Read16(data, 12) == 418) && (!mState.KnowsAriaOfPassion))
 			{
 				uint16_t zoneId = m_AshitaCore->GetMemoryManager()->GetParty()->GetMemberZone(0);
-				if (!(CheckForEquippableItem(22305) && (zoneId == 275 || zoneId == 133 || zoneId == 189) && !CheckForEquippableItem(22306) && !CheckForEquippableItem(22307)))
+				if (!(CheckForEquippableItem(22305) && (zoneId == 275 || zoneId == 133 || zoneId == 189)) || CheckForEquippableItem(22306) || CheckForEquippableItem(22307))
 				{
 					pOutput->error("No Loughnashade in equippable bags.  Aria of Passion packet blocked.");
 					return true;

--- a/readme.md
+++ b/readme.md
@@ -51,6 +51,10 @@ Note that the server still requires Twilight Cloak equipped for cast to begin an
 When enabled, this modifies the game client to believe you currently know Honor March.  This allows you to cast through menu, or by typing the command, without Marsyas on.<br>
 Note that the server still requires Marsyas equipped for cast to begin and complete, so you must equip it in the macro prior to the cast line or have Ashitacast configured to equip it in precast and midcast.
 
+* /shh aria [optional: on/off]<br>
+When enabled, this modifies the game client to believe you currently know Aria of Passion.  This allows you to cast through menu, or by typing the command, without Loughnashade on.<br>
+Note that the server still requires Loughnashade to be equipped for cast to begin and complete, so you must equip it in the macro prior to the cast line or have Ashitacast configured to equip it in precast and midcast.
+
 * /shh dispelga [optional: on/off]<br>
 When enabled, this modifies the game client to believe you currently know Dispelga.  This allows you to cast through menu, or by typing the command, without Daybreak on.<br>
 Note that the server still requires Daybreak equipped for cast to begin and complete, so you must equip it in the macro prior to the cast line or have Ashitacast configured to equip it in precast and midcast.


### PR DESCRIPTION
Adds an option to override gear requirements for Aria of Passion, similar to Honor March.  Includes an optional check for Loughnashade, and a zone check for stage 3 Loughnashade.